### PR TITLE
Fix for AAC+ streaming problems on Symbian phones

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -226,6 +226,8 @@ int format_general_headers (format_plugin_t *plugin, client_t *client)
                     fmtcode = FMT_RETURN_ICY;
                 if (strstr (useragent, "Windows-Media-Player")) /* hack for wmp*/
                     fmtcode = FMT_RETURN_ICY;
+                if (strstr (useragent, "RealMedia")) /* hack for rp (mainly mobile) */
+                    fmtcode = FMT_RETURN_ICY;
                 if (strstr (useragent, "Shoutcast Server")) /* hack for sc_serv */
                     fmtcode = FMT_LOWERCASE_TYPE;
                 // if (strstr (useragent, "Sonos"))


### PR DESCRIPTION
This should fix a problem on Symbian phones with icecast/Internet Radio apps refusing to connect to the stream if they should receive an AAC+ stream. Just replaced the protocol to ICY, now it should work.
