### PR TITLE
Handle empty auth username to ensure valid CLF formatting in access logging

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -98,7 +98,7 @@ void logging_access_id (access_log *accesslog, client_t *client)
 
         log_write_direct (accesslog->logid,
                 "%s - %s %s %s %d %" PRIu64 " %.150s %.150s %lu",
-                ip, username, datebuf, rq, client->respcode, client->connection.sent_bytes,
+                ip, un, datebuf, rq, client->respcode, client->connection.sent_bytes,
                 rf, ua, (unsigned long)stayed);
         free (ua);
         free (rf);

--- a/src/logging.c
+++ b/src/logging.c
@@ -81,7 +81,7 @@ void logging_access_id (access_log *accesslog, client_t *client)
 
     // set username to '-' when client->username is empty
     if (client->username != NULL && strlen(client->username) > 0)
-        username = util_url_escape(client->username); // no spaces allowed in authuser field
+        username = strdup(client->username);
 
     referrer = httpp_getvar (client->parser, "referer");
     user_agent = httpp_getvar (client->parser, "user-agent");
@@ -91,7 +91,8 @@ void logging_access_id (access_log *accesslog, client_t *client)
 
     if (accesslog->type == LOG_ACCESS_CLF_ESC)
     {
-        char *rq = util_url_escape (reqbuf),
+        char *un = util_url_escape (username),
+             *rq = util_url_escape (reqbuf),
              *rf = referrer ? util_url_escape (referrer) : strdup ("-"),
              *ua = user_agent ? util_url_escape (user_agent) : strdup ("-");
 
@@ -102,6 +103,7 @@ void logging_access_id (access_log *accesslog, client_t *client)
         free (ua);
         free (rf);
         free (rq);
+        free (un);
     }
     else
     {

--- a/src/logging.c
+++ b/src/logging.c
@@ -55,7 +55,8 @@ void logging_access_id (access_log *accesslog, client_t *client)
     const char *req = NULL;
     time_t now;
     time_t stayed;
-    const char *referrer, *user_agent, *username, *ip = "-";
+    const char *referrer, *user_agent, *ip = "-";
+    char *username = strdup("-");
     char datebuf[50];
     char reqbuf[256];
 
@@ -77,7 +78,11 @@ void logging_access_id (access_log *accesslog, client_t *client)
             httpp_getvar (client->parser, HTTPP_VAR_VERSION));
 
     stayed = now - client->connection.con_time;
-    username = client->username;
+
+    // set username to '-' when client->username is empty
+    if (client->username != NULL && strlen(client->username) > 0)
+        username = util_url_escape(client->username); // no spaces allowed in authuser field
+
     referrer = httpp_getvar (client->parser, "referer");
     user_agent = httpp_getvar (client->parser, "user-agent");
 
@@ -86,31 +91,31 @@ void logging_access_id (access_log *accesslog, client_t *client)
 
     if (accesslog->type == LOG_ACCESS_CLF_ESC)
     {
-        char *un = client->username ? util_url_escape (username) : strdup ("-"),
-             *rq = util_url_escape (reqbuf),
+        char *rq = util_url_escape (reqbuf),
              *rf = referrer ? util_url_escape (referrer) : strdup ("-"),
              *ua = user_agent ? util_url_escape (user_agent) : strdup ("-");
 
         log_write_direct (accesslog->logid,
                 "%s - %s %s %s %d %" PRIu64 " %.150s %.150s %lu",
-                ip, un, datebuf, rq, client->respcode, client->connection.sent_bytes,
+                ip, username, datebuf, rq, client->respcode, client->connection.sent_bytes,
                 rf, ua, (unsigned long)stayed);
         free (ua);
         free (rf);
         free (rq);
-        free (un);
     }
     else
     {
-        if (client->username == NULL)   username = "-"; 
-        if (referrer == NULL)           referrer = "-";
-        if (user_agent == NULL)         user_agent = "-";
+        if (referrer == NULL)   referrer = "-";
+        if (user_agent == NULL) user_agent = "-";
 
         log_write_direct (accesslog->logid,
                 "%s - %s [%s] \"%s\" %d %" PRIu64 " \"%.150s\" \"%.150s\" %lu",
                 ip, username, datebuf, reqbuf, client->respcode, client->connection.sent_bytes,
                 referrer, user_agent, (unsigned long)stayed);
     }
+
+    free(username);
+
     client->respcode = -1;
 }
 


### PR DESCRIPTION
Hi Karl,

When the auth username is not specified by the source client, this results in an empty string which causes a log line where the second dash (-) is missing. The access.log line is no longer CLF compliant and cannot be parsed correctly.

This patch ensures that dash (-) is used for auth username in this case.

Can you please merge this into icecast-kh too?

Kind regards,
Klaas Jan
