### PR TITLE
Fix setresgid() (gid not uid)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -330,7 +330,7 @@ static void _ch_root_uid_setup(void)
            else
                fprintf (stdout, "Changed supplementary groups based on user: %s.\n", conf->user);
 #ifdef HAVE_SETRESGID
-           if (setresgid (uid, uid, uid) < 0)
+           if (setresgid (gid, gid, gid) < 0)
 #else
            if (setgid (gid) < 0)
 #endif


### PR DESCRIPTION
Last commit (0ff33d5) on `src/main.c` apparently contains a typo, which makes Icecast request the user id given in the config file as its real/effective group id.

Example in strace:
```
setgroups(1, [65534]) = 0
fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 1), ...}) = 0
mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fa41b825000
write(1, "Changed supplementary groups bas"..., 54) = 54
setresgid(110, 110, 110) = 0
write(1, "Changed groupid to 65534.\n", 26) = 26
setresuid(110, 110, 110) = 0
write(1, "Changed userid to 110.\n", 23) = 23
```