### PR TITLE
Fix 2 warnings when building with Clang

### DIFF
--- a/src/log/log.h
+++ b/src/log/log.h
@@ -39,7 +39,7 @@ void log_close(int log_id);
 void log_shutdown(void);
 
 void log_write(int log_id, unsigned priority, const char *cat, const char *func, 
-        const char *fmt, ...)  __attribute__ ((format (gnu_printf, 5, 6)));
-void log_write_direct(int log_id, const char *fmt, ...) __attribute__ ((format (gnu_printf, 2, 3)));
+        const char *fmt, ...)  __attribute__ ((format (printf, 5, 6)));
+void log_write_direct(int log_id, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 #endif  /* __LOG_H__ */


### PR DESCRIPTION
__attribute__ ((format (printf, 5, 6))) is supported by both GCC and Clang.

This fixes the following warnings:

In file included from log.c:33:
./log.h:42:48: warning: format attribute argument not supported: gnu_printf [-Wignored-attributes]
        const char *fmt, ...)  __attribute__ ((format (gnu_printf, 5, 6)));
                                               ^
./log.h:43:73: warning: format attribute argument not supported: gnu_printf [-Wignored-attributes]
void log_write_direct(int log_id, const char *fmt, ...) __attribute__ ((format (gnu_printf, 2, 3)));
                                                                        ^
2 warnings generated.