### PR TITLE
Check for signal.h at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_TIME
 
-AC_CHECK_HEADERS([fcntl.h fnmatch.h sys/timeb.h sys/wait.h alloca.h malloc.h glob.h winsock2.h windows.h stdbool.h])
+AC_CHECK_HEADERS([fcntl.h fnmatch.h signal.h sys/timeb.h sys/wait.h alloca.h malloc.h glob.h winsock2.h windows.h stdbool.h])
 AC_CHECK_HEADERS(pwd.h, AC_DEFINE(CHUID, 1, [Define if you have pwd.h]),,)
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
Check for that header file to prevent HAVE_SIGNAL_H
from being wrongly undefined when compiling auth_cmd.c
on FreeBSD and possibly other operating systems.