### PR TITLE
Remove now-always-unmet condition HAVE_SIGNAL_H

### DIFF
--- a/src/auth_cmd.c
+++ b/src/auth_cmd.c
@@ -29,14 +29,12 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
+#include <signal.h>
 #ifndef WIN32
 #include <sys/wait.h>
 #endif
 #ifdef HAVE_POLL
 #include <poll.h>
-#endif
-#ifdef HAVE_SIGNAL_H
-#include <signal.h>
 #endif
 
 #include "auth.h"


### PR DESCRIPTION
Since header file signal.h has been removed from an
AC_CHECK_HEADERS macro of configure.ac, HAVE_SIGNAL_H
is always undefined at preprocessing time. This results
in compilation failure in FreeBSD and possibly other
operating systems.