### PR TITLE
add Icy-MetaData to Access-Control-Allow-Headers

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -359,7 +359,7 @@ int client_send_options(client_t *client)
             "HTTP/1.1 200 OK\r\n"
             "Connection: Keep-alive\r\n"
             "Access-Control-Allow-Origin: *\r\n"
-            "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type\r\n"
+            "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type, Icy-MetaData\r\n"
             "Access-Control-Allow-Methods: GET, OPTIONS, HEAD, STATS\r\n\r\n");
     client->respcode = 200;
     client->refbuf->len = strlen (client->refbuf->data);

--- a/src/format.c
+++ b/src/format.c
@@ -551,7 +551,7 @@ int format_general_headers (format_plugin_t *plugin, client_t *client)
     /* prevent proxy servers from caching */
     bytes = snprintf (ptr, remaining, "Cache-Control: no-cache, no-store\r\n"
             "Access-Control-Allow-Origin: *\r\n"
-            "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type\r\n"
+            "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type, Icy-MetaData\r\n"
             "Access-Control-Allow-Methods: GET, OPTIONS, HEAD\r\n"
             "%s\r\n"
             "Expires: Mon, 26 Jul 1997 05:00:00 GMT\r\n", client_keepalive_header (client));


### PR DESCRIPTION
Some providers use HTML5 audio players that read metadata from the stream.
This allows them to ask for the metadata via the Icy-MetaData request header.