### PR TITLE
add `Icy-` headers to Access-Control-Expose-Headers

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -363,7 +363,8 @@ int client_add_cors (client_t *client, char *buf, int remain)
     bytes = snprintf (buf, remain,
             "Access-Control-Allow-Origin: %s\r\n%s"
             "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type, Icy-MetaData\r\n"
-            "Access-Control-Allow-Methods: GET, OPTIONS, SOURCE, PUT, HEAD, STATS\r\n\r\n",
+            "Access-Control-Expose-Headers: Icy-MetaInt, Icy-Br, Icy-Description, Icy-Genre, Icy-Name, Ice-Audio-Info, Icy-Url, Icy-Sr, Icy-Vbr, Icy-Pub\r\n"
+	    "Access-Control-Allow-Methods: GET, OPTIONS, SOURCE, PUT, HEAD, STATS\r\n\r\n",
             origin, cred);
     return bytes;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -364,7 +364,7 @@ int client_add_cors (client_t *client, char *buf, int remain)
             "Access-Control-Allow-Origin: %s\r\n%s"
             "Access-Control-Allow-Headers: Origin, Accept, X-Requested-With, Content-Type, Icy-MetaData\r\n"
             "Access-Control-Expose-Headers: Icy-MetaInt, Icy-Br, Icy-Description, Icy-Genre, Icy-Name, Ice-Audio-Info, Icy-Url, Icy-Sr, Icy-Vbr, Icy-Pub\r\n"
-	    "Access-Control-Allow-Methods: GET, OPTIONS, SOURCE, PUT, HEAD, STATS\r\n\r\n",
+            "Access-Control-Allow-Methods: GET, OPTIONS, SOURCE, PUT, HEAD, STATS\r\n\r\n",
             origin, cred);
     return bytes;
 }


### PR DESCRIPTION
Adds CORS configuration to allow `Icy-` headers to be read in a cross origin browser request. `Icy-MetaInt` is important to read so the client can parse metadata correctly. The other `Icy-` headers give additional information to the client about a stream.

Resolves #338 