### PR TITLE
Memory corruption in FLV wrapping if there is not enough allocated space for metadata

### DIFF
--- a/src/flv.h
+++ b/src/flv.h
@@ -44,3 +44,4 @@ refbuf_t *flv_meta_allocate (size_t len);
 void flv_meta_append_string (refbuf_t *buffer, const char *tag, const char *value);
 void flv_meta_append_number (refbuf_t *buffer, const char *tag, double value);
 void flv_meta_append_bool (refbuf_t *buffer, const char *tag, int value);
+void flv_meta_append_end_marker (refbuf_t *buffer);

--- a/src/format_mp3.c
+++ b/src/format_mp3.c
@@ -461,7 +461,7 @@ static void mp3_set_title (source_t *source)
         DEBUG1 ("icy metadata as %.80s...", p->data+1);
         yp_touch (source->mount, source->stats);
 
-        flv_meta_append_string (flvmeta, NULL, NULL);
+        flv_meta_append_end_marker (flvmeta);
 
         if (ib_len > 0) ib_len--; // add nul char to help parsing
         iceblock->len -= ib_len;


### PR DESCRIPTION
We had a crash when station was using long name. This is the situation:

- You have a relay ICY stream with long stream name (e.g. >180chars, <195 chars).
- You have a client requesting FLV wrapping.
- The client connects to the stream before ICY metadata is sent, so the flvmeta allocation happens in flv_write_metadata where it's limited to 200 bytes.
- It manages to add the "name" field to the flvmeta object and then maybe some small bool fields.
- For anything larger there isn't enough space, but each time there isn't enough space, it appends `"\x00\x00\x09"` to the meta buffer without checking the size.
- When this happens enough times, it overwrites the allocated space.

In the log file, it looks like this:

```
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
[2021-02-17  08:37:58] DBUG flv/flv_meta_increase 4 array elements
```

Then there is some other activity and then it crashes, because of the corrupted memory.

The fix does two things:
 - Makes sure that `"\x00\x00\x09"` is appended to the flvmeta only once, and only if there is enough space.
 - Allocates 4000 bytes in flv_write_metadata, just like it's done in mp3_set_title.

With this patch (and assuming the stream name is really super long, but below the 4000 - 5 bytes), the error log looks like this:

```
[2021-02-17  08:48:41] WARN flv/flv_meta_append_number not enough space for audiodatarate
[2021-02-17  08:48:41] WARN flv/flv_meta_append_number not enough space for audiosamplerate
[2021-02-17  08:48:41] WARN flv/flv_meta_append_bool not enough space for canSeekToEnd
[2021-02-17  08:48:41] WARN flv/flv_meta_append_bool not enough space for hasMetadata
[2021-02-17  08:48:41] WARN flv/flv_meta_append_bool not enough space for hasVideo
[2021-02-17  08:48:41] WARN flv/flv_meta_append_bool not enough space for hasAudio
```