### PR TITLE
Use relative URLs on public HTML/XSL pages.

### DIFF
--- a/admin/listclients.xsl
+++ b/admin/listclients.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body bgcolor="#000" topmargin="0" leftmargin="0" rightmargin="0" bottommargin="0">
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <xsl:for-each select="source">
@@ -27,7 +27,7 @@
                 <td><h3>Mount Point <xsl:value-of select="@mount" /></h3></td>
                 <xsl:choose>
                     <xsl:when test="authenticator">
-                        <td align="right"><a class="auth" href="/auth.xsl">Login</a></td>
+                        <td align="right"><a class="auth" href="../auth.xsl">Login</a></td>
                     </xsl:when>
                     <xsl:otherwise>
                         <td align="right"> <a href="{@mount}.m3u">M3U</a> <a href="{@mount}.xspf">XSPF</a></td>
@@ -73,7 +73,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/listmounts.xsl
+++ b/admin/listmounts.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body>
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <xsl:for-each select="source">
@@ -27,7 +27,7 @@
                 <td><h3>Mount Point <xsl:value-of select="@mount" /></h3></td>
                 <xsl:choose>
                     <xsl:when test="authenticator">
-                        <td align="right"><a class="auth" href="/auth.xsl">Login</a></td>
+                        <td align="right"><a class="auth" href="../auth.xsl">Login</a></td>
                     </xsl:when>
                     <xsl:otherwise>
                         <td align="right"> <a href="{@mount}.m3u">M3U</a> <a href="{@mount}.xspf">XSPF</a></td>
@@ -78,7 +78,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/logs.xsl
+++ b/admin/logs.xsl
@@ -6,7 +6,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body>
 
@@ -14,7 +14,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Access log</h3>
@@ -23,7 +23,7 @@ no frame support however contents can be found <a href="showlog.xsl?log=accesslo
 </iframe>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />
@@ -31,7 +31,7 @@ no frame support however contents can be found <a href="showlog.xsl?log=accesslo
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Error log</h3>
@@ -40,7 +40,7 @@ no frame support however contents can be found <a href="showlog.xsl?log=errorlog
 </iframe>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />
@@ -48,7 +48,7 @@ no frame support however contents can be found <a href="showlog.xsl?log=errorlog
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Playlist log</h3>
@@ -57,7 +57,7 @@ no frame support however contents can be found <a href="showlog.xsl?log=playlist
 </iframe>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />

--- a/admin/manageauth.xsl
+++ b/admin/manageauth.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body bgcolor="#000" topmargin="0" leftmargin="0" rightmargin="0" bottommargin="0">
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <xsl:for-each select="iceresponse">
@@ -72,7 +72,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/managerelays.xsl
+++ b/admin/managerelays.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body>
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <xsl:for-each select="relay">
@@ -45,7 +45,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/moveclients.xsl
+++ b/admin/moveclients.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body bgcolor="#000" topmargin="0" leftmargin="0" rightmargin="0" bottommargin="0">
 
@@ -16,7 +16,7 @@
 <xsl:variable name = "currentmount" ><xsl:value-of select="current_source" /></xsl:variable>
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Move to which mountpoint ?</h3>
@@ -34,7 +34,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/response.xsl
+++ b/admin/response.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body>
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Response</h3>
@@ -27,7 +27,7 @@ Return Code: <xsl:value-of select="return" /><br></br>
 <br />
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/admin/stats.xsl
+++ b/admin/stats.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body bgcolor="#000" topmargin="0" leftmargin="0" rightmargin="0" bottommargin="0">
 
@@ -18,7 +18,7 @@
 <!--global server stats-->
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Global Server Stats</h3>
@@ -36,7 +36,7 @@
 </table>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />
@@ -47,7 +47,7 @@
 <xsl:for-each select="source">
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <div class="streamheader">
@@ -58,7 +58,7 @@
             <td><h3>Mount Point <xsl:value-of select="@mount" /></h3></td>
             <xsl:choose>
                 <xsl:when test="authenticator">
-                    <td align="right"><a class="auth" href="/auth.xsl">Login</a></td>
+                    <td align="right"><a class="auth" href="../auth.xsl">Login</a></td>
                 </xsl:when>
                 <xsl:otherwise>
                     <td align="right"> <a href="{@mount}.m3u">M3U</a> <a href="{@mount}.xspf">XSPF</a></td>
@@ -93,7 +93,7 @@
 </table>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />

--- a/admin/updatemetadata.xsl
+++ b/admin/updatemetadata.xsl
@@ -7,7 +7,7 @@
 <html>
 <head>
 <title>Icecast Streaming Media Server</title>
-<link rel="stylesheet" type="text/css" href="/style.css" />
+<link rel="stylesheet" type="text/css" href="../style.css" />
 </head>
 <body bhcolor="#000" topmargin="0" leftmargin="0" rightmargin="0" bottommargin="0">
 
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <xsl:for-each select="source">
@@ -39,7 +39,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="../images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <div class="poster">Support icecast development at <a class="nav" href="http://www.icecast.org">www.icecast.org</a></div>

--- a/web/admin.html
+++ b/web/admin.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <link rel="stylesheet" type="text/css" href="./style.css" />
     <title>Icecast Streaming Media Server</title>
   </head>
 
   <frameset rows="170,*" border="0">
-      <frame name="header" frameborder="0" scrolling="no" width="100%" src="/adminbar.html" />
-      <frame name="content" frameborder="0" scrolling="auto" width="100%" src="/admin/stats.xsl" />
+      <frame name="header" frameborder="0" scrolling="no" width="100%" src="./adminbar.html" />
+      <frame name="content" frameborder="0" scrolling="auto" width="100%" src="./admin/stats.xsl" />
   </frameset>
 </html>

--- a/web/adminbar.html
+++ b/web/adminbar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <link rel="stylesheet" type="text/css" href="./style.css" />
     <title>Icecast Streaming Media Server</title>
   </head>
 
@@ -17,12 +17,12 @@
           <table>
             <tr>
               <td>
-                <a target="content" href="/admin/stats.xsl">Admin Home</a>
-                <a target="content" href="/admin/listmounts.xsl">List Mountpoints</a>
-                <a target="content" href="/admin/managerelays.xsl">Manage Relays</a>
-                <a target="content" href="/admin/function.xsl?perform=updatecfg">Reload Config</a>
-                <a target="content" href="/admin/logs.xsl">Logs</a>
-                <a target="_parent" href="/index.html">Index</a>
+                <a target="content" href="./admin/stats.xsl">Admin Home</a>
+                <a target="content" href="./admin/listmounts.xsl">List Mountpoints</a>
+                <a target="content" href="./admin/managerelays.xsl">Manage Relays</a>
+                <a target="content" href="./admin/function.xsl?perform=updatecfg">Reload Config</a>
+                <a target="content" href="./admin/logs.xsl">Logs</a>
+                <a target="_parent" href="./index.html">Index</a>
               </td>
             </tr>
           </table>

--- a/web/auth.xsl
+++ b/web/auth.xsl
@@ -19,7 +19,7 @@
 <td>
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="./images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 
 <div class="newscontent">
@@ -43,7 +43,7 @@
 <xsl:text disable-output-escaping="yes">&amp;</xsl:text>nbsp;
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="./images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br></br><br></br>

--- a/web/index.html
+++ b/web/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <link rel="stylesheet" type="text/css" href="./style.css" />
     <title>Icecast Streaming Media Server</title>
   </head>
 
   <frameset rows="170,*" border="0">
-      <frame name="header" frameborder="0" scrolling="no" width="100%" src="/statusbar.html" />
-      <frame name="content" frameborder="0" scrolling="auto" width="100%" src="/status.xsl" />
+      <frame name="header" frameborder="0" scrolling="no" width="100%" src="./statusbar.html" />
+      <frame name="content" frameborder="0" scrolling="auto" width="100%" src="./status.xsl" />
   </frameset>
 </html>

--- a/web/server_version.xsl
+++ b/web/server_version.xsl
@@ -15,7 +15,7 @@
 
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" />
+<img src="./images/corner_topleft.jpg" class="corner" style="display: none" />
 </div>
 <div class="newscontent">
 <h3>Information</h3>
@@ -66,7 +66,7 @@
 </table>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" />
+<img src="./images/corner_bottomleft.jpg" class="corner" style="display: none" />
 </div>
 </div>
 <br />

--- a/web/status.xsl
+++ b/web/status.xsl
@@ -17,7 +17,7 @@
 <xsl:for-each select="source">
 <div class="roundcont">
 <div class="roundtop">
-<img src="/images/corner_topleft.jpg" class="corner" style="display: none" alt=""/>
+<img src="./images/corner_topleft.jpg" class="corner" style="display: none" alt=""/>
 </div>
 <div class="newscontent">
     <div class="streamheader">
@@ -28,10 +28,10 @@
                 <td><h3>Mount Point <xsl:value-of select="@mount" /></h3></td>
                 <xsl:choose>
                     <xsl:when test="authenticator">
-                        <td align="right"><a class="auth" href="/auth.xsl">Login</a></td>
+                        <td align="right"><a class="auth" href="./auth.xsl">Login</a></td>
                     </xsl:when>
                     <xsl:otherwise>
-                        <td align="right"> <a href="{@mount}.m3u">M3U</a> <a href="{@mount}.xspf">XSPF</a></td>
+                        <td align="right"> <a href=".{@mount}.m3u">M3U</a> <a href=".{@mount}.xspf">XSPF</a></td>
                     </xsl:otherwise>
                 </xsl:choose>
         </tr></table>
@@ -94,7 +94,7 @@
 </table>
 </div>
 <div class="roundbottom">
-<img src="/images/corner_bottomleft.jpg" class="corner" style="display: none" alt="" />
+<img src="./images/corner_bottomleft.jpg" class="corner" style="display: none" alt="" />
 </div>
 </div>
 <br />

--- a/web/statusbar.html
+++ b/web/statusbar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <link rel="stylesheet" type="text/css" href="./style.css" />
     <title>Icecast Streaming Media Server</title>
   </head>
 
@@ -16,9 +16,9 @@
           <table>
               <tr>
                   <td>
-                      <a target="_parent" href="/admin.html">Admin</a>
-                      <a target="content" href="/status.xsl">Status</a>
-                      <a target="content" href="/server_version.xsl">Info</a>
+                      <a target="_parent" href="./admin.html">Admin</a>
+                      <a target="content" href="./status.xsl">Status</a>
+                      <a target="content" href="./server_version.xsl">Info</a>
                       <a target="content" href="http://dir.xiph.org/">Stream Directory</a>
                   </td>
             </tr>

--- a/web/style.css
+++ b/web/style.css
@@ -38,7 +38,7 @@ html, body {
     padding-bottom: 0px;
     padding-left: 90px;
     height: 70px;
-    background: url(/images/icecast.png) no-repeat left center;
+    background: url(images/icecast.png) no-repeat left center;
 }
 .nav {
 	font-family: Verdana, sans-serif;
@@ -74,7 +74,7 @@ html, body {
     padding-left: 90px;
     margin-top: 0px;
     margin-bottom: 10px;
-    background: url(/images/icecast.png) no-repeat left center;
+    background: url(images/icecast.png) no-repeat left center;
 }
 .main iframe {
     width: 100%;
@@ -201,13 +201,13 @@ h3 {
     padding: 8px 5px 3px 30px;
     text-decoration: none;
     margin: 0px 0px 0px 20px;
-    background: transparent url("/images/tunein.png") no-repeat left center;
+    background: transparent url("images/tunein.png") no-repeat left center;
 }
 .streamheader a.auth {
     margin: 0px;
     padding-top: 14px;
     padding-bottom: 14px;
-    background: transparent url("/images/key.png") no-repeat left center;
+    background: transparent url("images/key.png") no-repeat left center;
 }
 .newscontent a {
     font-family: Verdana, sans-serif;


### PR DESCRIPTION
The sole purpose of this PR is to update the public-facing status and administration pages to use relative paths in their images, CSS and links.

In the typical environment of Icecast being served on a dedicated port, this has no impact on the frontend at all; however, if Icecast is found in a subfolder for any reason (i.e. via a port-80/443 web proxy service), it enables things to continue to look as intended in that environment as well.

In the longer term, it would likely be possible to remove the need for several of the images referenced entirely, as modern CSS support for things like `border-radius` has improved to such a degree that it is very safe to use that instead of rounded corner graphics. This PR does not address that and merely updates the paths for the current frontend.