### PR TITLE
Allow duplicate users by default when using URL auth

### DIFF
--- a/src/auth_url.c
+++ b/src/auth_url.c
@@ -872,6 +872,7 @@ int auth_get_url_auth (auth_t *authenticator, config_options_t *options)
         return 0;
     }
     char *pass_headers = NULL;
+    int check_duplicate_users = 0;
 
     authenticator->release = auth_url_clear;
     authenticator->adduser = auth_url_adduser;
@@ -972,8 +973,15 @@ int auth_get_url_auth (auth_t *authenticator, config_options_t *options)
             if (strcasecmp (options->value, "yes") == 0)
                 authenticator->flags |= AUTH_SKIP_IF_SLOW;
         }
+        if (!strcmp(options->name, "check_duplicate_users")) {
+            check_duplicate_users = atoi (options->value);
+        }
+
         options = options->next;
     }
+
+    if (!check_duplicate_users)
+        authenticator->flags |=  AUTH_ALLOW_LISTENER_DUP;
 
     if (url_info->auth_header)
         url_info->auth_header_len = strlen (url_info->auth_header);

--- a/src/source.c
+++ b/src/source.c
@@ -2788,7 +2788,7 @@ int source_add_listener (const char *mount, mount_proxy *mountinfo, client_t *cl
             thread_rwlock_unlock (&source->lock);
             if (minfo != mountinfo)
                 config_release_mount (minfo);
-            return client_send_403 (client, "Account already in use");
+            return client_send_403 (client, "Account already in use (listener)");
         }
 
         /* set a per-mount disconnect time if auth hasn't set one already */


### PR DESCRIPTION
Current URL auth implementation in Icecast only allows one user to be connected with the same username/password credentials. This is also true for password protected streams when username is empty and only password is used. And in most cases this is not desired, especially when URL auth is used to conditionally allow access to the stream.

This change adds check_duplicate_users config option for mount to control this, and by default duplicate users are not checked. 