### PR TITLE
fix: case sensitive cors value

### DIFF
--- a/src/params.c
+++ b/src/params.c
@@ -520,7 +520,7 @@ ice_config_http_header_t default_headers[] =
     { .hdr = { .status = "2*",          .name = "Access-Control-Allow-Credentials",
                                         .value = "true", .callback = _send_cors_hdr } },
     { .hdr = { .status = "2*",          .name = "Access-Control-Allow-Headers",
-                                        .value = "Origin, Icy-MetaData, Range",
+                                        .value = "Origin, Icy-MetaData, Range, Authorization",
                                         .callback = _send_cors_hdr } },
     { .hdr = { .status = "2*",          .name = "Access-Control-Expose-Headers",
                                         .value = "Icy-Br, Icy-Description, Icy-Genre, Icy-MetaInt, Icy-Name, Icy-Pub, Icy-Url",

--- a/src/params.c
+++ b/src/params.c
@@ -518,7 +518,7 @@ ice_config_http_header_t default_headers[] =
                                         .value = "*",
                                         .callback = _send_cors_hdr } },
     { .hdr = { .status = "2*",          .name = "Access-Control-Allow-Credentials",
-                                        .value = "True", .callback = _send_cors_hdr } },
+                                        .value = "true", .callback = _send_cors_hdr } },
     { .hdr = { .status = "2*",          .name = "Access-Control-Allow-Headers",
                                         .value = "Origin, Icy-MetaData, Range",
                                         .callback = _send_cors_hdr } },


### PR DESCRIPTION
The `Access-Control-Allow-Credentials` CORS header value should be `true`. It's case-sensitive according to the spec, and browsers don't accept `True`.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials#directives
See eshaz/icecast-metadata-js#183