### PR TITLE
write out the initial FLV header immediately

### DIFF
--- a/src/flv.c
+++ b/src/flv.c
@@ -365,6 +365,8 @@ int write_flv_buf_to_client (client_t *client)
             memcpy (flv->wrapper->data, header, 9);
             connection_bufs_append (&flv->bufs, flv->wrapper->data, 9);
             flv->wrapper_offset += 9;
+
+            ret = send_flv_buffer (client, flv);
         }
         flv->samples -= flv->samples_in_buffer; // role back the sample count;
 


### PR DESCRIPTION
write out the initial FLV header immediately to avoid AAC streams overwriting it on first audio frame